### PR TITLE
[fix] 修复 flex_button_register 返回值类型为 int32_t，当出现错误的时候返回 -1

### DIFF
--- a/flexible_button.c
+++ b/flexible_button.c
@@ -88,9 +88,9 @@ static uint8_t button_cnt = 0;
  * @brief Register a user button
  * 
  * @param button: button structure instance
- * @return Number of keys that have been registered
+ * @return Number of keys that have been registered, or -1 when error
 */
-uint8_t flex_button_register(flex_button_t *button)
+int32_t flex_button_register(flex_button_t *button)
 {
     flex_button_t *curr = btn_head;
     

--- a/flexible_button.h
+++ b/flexible_button.h
@@ -145,7 +145,7 @@ typedef struct flex_button
 extern "C" {
 #endif
 
-uint8_t flex_button_register(flex_button_t *button);
+int32_t flex_button_register(flex_button_t *button);
 flex_button_event_t flex_button_event_read(flex_button_t* button);
 uint8_t flex_button_scan(void);
 


### PR DESCRIPTION
[fix] 修复 flex_button_register 返回值类型为 int32_t，当出现错误的时候返回 -1

@wzd5230 注意同步